### PR TITLE
Add static html fallbacks for privacy and tos

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,7 @@
   <body>
     <div id="root">
       <!-- Static content for crawlers and users with JavaScript disabled -->
+      <!-- Note: Static HTML versions of legal pages are available at /privacy.html and /tos.html -->
       <div style="max-width: 800px; margin: 0 auto; padding: 20px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6;">
         <header style="text-align: center; margin-bottom: 30px;">
           <h1 style="color: #333; margin-bottom: 10px;">Email Sales Map</h1>

--- a/frontend/public/privacy.html
+++ b/frontend/public/privacy.html
@@ -1,0 +1,275 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy - Email Sales Map</title>
+    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7C1T7EM1M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-M7C1T7EM1M');
+    </script>
+    
+    <style>
+      .legal-page {
+        min-height: 100vh;
+        background: #f8fafc;
+        padding: 2rem 1rem;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+
+      .legal-container {
+        max-width: 800px;
+        margin: 0 auto;
+        background: white;
+        border-radius: 12px;
+        padding: 3rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        line-height: 1.6;
+      }
+
+      .legal-header {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 3px solid #3182ce;
+      }
+
+      .legal-logo {
+        width: 64px;
+        height: 64px;
+        object-fit: contain;
+        margin-top: 0.5rem;
+      }
+
+      .legal-container h1 {
+        font-size: 2.5rem;
+        font-weight: 700;
+        color: #1a202c;
+        margin-bottom: 0.5rem;
+      }
+
+      .last-updated {
+        font-style: italic;
+        color: #718096;
+        margin-bottom: 2rem;
+        font-size: 0.9rem;
+      }
+
+      .legal-container section {
+        margin-bottom: 2rem;
+      }
+
+      .legal-container h2 {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: #2d3748;
+        margin-bottom: 1rem;
+        margin-top: 2rem;
+      }
+
+      .legal-container p {
+        color: #4a5568;
+        margin-bottom: 1rem;
+      }
+
+      .legal-container ul {
+        color: #4a5568;
+        margin-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .legal-container li {
+        margin-bottom: 0.5rem;
+      }
+
+      .legal-container strong {
+        color: #2d3748;
+        font-weight: 600;
+      }
+
+      .legal-footer {
+        margin-top: 3rem;
+        padding-top: 2rem;
+        border-top: 1px solid #e2e8f0;
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      .legal-footer a {
+        color: #3182ce;
+        text-decoration: none;
+        font-weight: 500;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        transition: all 0.2s ease;
+      }
+
+      .legal-footer a:hover {
+        background: #ebf8ff;
+        color: #2c5282;
+      }
+
+      @media (max-width: 768px) {
+        .legal-container {
+          padding: 2rem 1.5rem;
+        }
+        
+        .legal-header {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+        
+        .legal-logo {
+          width: 48px;
+          height: 48px;
+          margin-top: 0;
+        }
+        
+        .legal-container h1 {
+          font-size: 2rem;
+        }
+        
+        .legal-footer {
+          flex-direction: column;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="legal-page">
+      <div class="legal-container">
+        <div class="legal-header">
+          <img src="/logo.svg" alt="Email Sales Map Logo" class="legal-logo" />
+          <div>
+            <h1>Privacy Policy</h1>
+            <p class="last-updated">Last updated: August 17, 2025</p>
+          </div>
+        </div>
+
+        <section>
+          <h2>1. Information We Collect</h2>
+          <p>
+            Email Sales Map ("we," "our," or "us") collects the following information when you use our service:
+          </p>
+          <ul>
+            <li><strong>Google Account Information:</strong> Your email address and basic profile information through Google OAuth</li>
+            <li><strong>Gmail Data:</strong> We read emails matching your configured criteria to extract country information</li>
+            <li><strong>Usage Data:</strong> Basic analytics about how you interact with our application</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>2. How We Use Your Information</h2>
+          <p>We use your information solely to:</p>
+          <ul>
+            <li>Authenticate you through Google OAuth</li>
+            <li>Scan your Gmail for sales notification emails matching your configured criteria</li>
+            <li>Extract country data from these emails</li>
+            <li>Display aggregated sales data on an interactive world map</li>
+            <li>Provide session management for your account</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>3. Data Storage and Security</h2>
+          <ul>
+            <li><strong>Session Data:</strong> Stored temporarily in Cloudflare KV storage for authentication</li>
+            <li><strong>Cache Data:</strong> Aggregated sales counts cached for 1 hour to improve performance</li>
+            <li><strong>No Email Storage:</strong> We do not store your email content - only extract and aggregate country data</li>
+            <li><strong>Encryption:</strong> All data transmission is encrypted using HTTPS</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>4. Data Sharing</h2>
+          <p>
+            We do not sell, trade, or share your personal information with third parties. Your data is used exclusively for the functionality described in this application.
+          </p>
+        </section>
+
+        <section>
+          <h2>5. Google API Services</h2>
+          <p>
+            This application uses Google APIs and is subject to Google's API Services User Data Policy, including the Limited Use requirements. We:
+          </p>
+          <ul>
+            <li>Only request the minimum necessary Gmail permissions (gmail.readonly)</li>
+            <li>Use your Gmail data solely for the stated purpose of extracting sales country data</li>
+            <li>Do not store or cache your email content</li>
+            <li>Comply with Google's Limited Use Policy</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>6. Data Retention</h2>
+          <ul>
+            <li><strong>Session Data:</strong> Automatically expires after 7 days</li>
+            <li><strong>Cache Data:</strong> Automatically expires after 1 hour</li>
+            <li><strong>Access Tokens:</strong> Refreshed as needed and not permanently stored</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>7. Your Rights</h2>
+          <p>You have the right to:</p>
+          <ul>
+            <li>Revoke access to your Gmail account at any time through your Google Account settings</li>
+            <li>Request deletion of your session data by signing out</li>
+            <li>Contact us with questions about your data</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>8. Third-Party Services</h2>
+          <p>
+            Our application is hosted on Cloudflare Pages and uses Cloudflare Workers for backend processing. 
+            These services are governed by Cloudflare's privacy policy.
+          </p>
+        </section>
+
+        <section>
+          <h2>9. Children's Privacy</h2>
+          <p>
+            Our service is not intended for users under 13 years of age. We do not knowingly collect 
+            personal information from children under 13.
+          </p>
+        </section>
+
+        <section>
+          <h2>10. Changes to This Policy</h2>
+          <p>
+            We may update this privacy policy from time to time. We will notify users of any material 
+            changes by updating the "Last updated" date at the top of this policy.
+          </p>
+        </section>
+
+        <section>
+          <h2>11. Contact Information</h2>
+          <p>
+            If you have any questions about this Privacy Policy, please contact us at:
+            <br />
+            Email: andrew.d.beveridge@gmail.com
+          </p>
+        </section>
+
+        <div class="legal-footer">
+          <a href="/">← Back to Email Sales Map</a>
+          <a href="/tos">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/frontend/public/tos.html
+++ b/frontend/public/tos.html
@@ -1,0 +1,318 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms of Service - Email Sales Map</title>
+    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7C1T7EM1M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-M7C1T7EM1M');
+    </script>
+    
+    <style>
+      .legal-page {
+        min-height: 100vh;
+        background: #f8fafc;
+        padding: 2rem 1rem;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+
+      .legal-container {
+        max-width: 800px;
+        margin: 0 auto;
+        background: white;
+        border-radius: 12px;
+        padding: 3rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        line-height: 1.6;
+      }
+
+      .legal-header {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 3px solid #3182ce;
+      }
+
+      .legal-logo {
+        width: 64px;
+        height: 64px;
+        object-fit: contain;
+        margin-top: 0.5rem;
+      }
+
+      .legal-container h1 {
+        font-size: 2.5rem;
+        font-weight: 700;
+        color: #1a202c;
+        margin-bottom: 0.5rem;
+      }
+
+      .last-updated {
+        font-style: italic;
+        color: #718096;
+        margin-bottom: 2rem;
+        font-size: 0.9rem;
+      }
+
+      .legal-container section {
+        margin-bottom: 2rem;
+      }
+
+      .legal-container h2 {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: #2d3748;
+        margin-bottom: 1rem;
+        margin-top: 2rem;
+      }
+
+      .legal-container p {
+        color: #4a5568;
+        margin-bottom: 1rem;
+      }
+
+      .legal-container ul {
+        color: #4a5568;
+        margin-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .legal-container li {
+        margin-bottom: 0.5rem;
+      }
+
+      .legal-container strong {
+        color: #2d3748;
+        font-weight: 600;
+      }
+
+      .legal-footer {
+        margin-top: 3rem;
+        padding-top: 2rem;
+        border-top: 1px solid #e2e8f0;
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      .legal-footer a {
+        color: #3182ce;
+        text-decoration: none;
+        font-weight: 500;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        transition: all 0.2s ease;
+      }
+
+      .legal-footer a:hover {
+        background: #ebf8ff;
+        color: #2c5282;
+      }
+
+      @media (max-width: 768px) {
+        .legal-container {
+          padding: 2rem 1.5rem;
+        }
+        
+        .legal-header {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+        
+        .legal-logo {
+          width: 48px;
+          height: 48px;
+          margin-top: 0;
+        }
+        
+        .legal-container h1 {
+          font-size: 2rem;
+        }
+        
+        .legal-footer {
+          flex-direction: column;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="legal-page">
+      <div class="legal-container">
+        <div class="legal-header">
+          <img src="/logo.svg" alt="Email Sales Map Logo" class="legal-logo" />
+          <div>
+            <h1>Terms of Service</h1>
+            <p class="last-updated">Last updated: August 17, 2025</p>
+          </div>
+        </div>
+
+        <section>
+          <h2>1. Acceptance of Terms</h2>
+          <p>
+            By accessing and using Email Sales Map ("the Service"), you accept and agree to be bound by the terms 
+            and provision of this agreement. If you do not agree to abide by the above, please do not use this service.
+          </p>
+        </section>
+
+        <section>
+          <h2>2. Description of Service</h2>
+          <p>
+            Email Sales Map is a data visualization tool that:
+          </p>
+          <ul>
+            <li>Authenticates users through Google OAuth</li>
+            <li>Reads emails matching your configured criteria in your Gmail account</li>
+            <li>Extracts country information from sales notification emails</li>
+            <li>Displays aggregated sales data on an interactive world map</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>3. User Accounts and Authentication</h2>
+          <ul>
+            <li>You must have a valid Google account to use this service</li>
+            <li>You are responsible for maintaining the security of your Google account</li>
+            <li>You grant us permission to access your Gmail with read-only privileges</li>
+            <li>You may revoke access at any time through your Google Account settings</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>4. Permitted Use</h2>
+          <p>You may use Email Sales Map to:</p>
+          <ul>
+            <li>Visualize your own sales data from any supported platform</li>
+            <li>View aggregated country statistics from your sales</li>
+            <li>Export or share anonymized visualizations</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>5. Prohibited Use</h2>
+          <p>You may not:</p>
+          <ul>
+            <li>Use the service for any illegal or unauthorized purpose</li>
+            <li>Attempt to gain unauthorized access to other users' data</li>
+            <li>Interfere with or disrupt the service or servers</li>
+            <li>Use automated tools to access the service without permission</li>
+            <li>Reverse engineer or attempt to extract the source code</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>6. Data and Privacy</h2>
+          <p>
+            Your use of Email Sales Map is also governed by our Privacy Policy. By using the service, 
+            you consent to the collection and use of information as outlined in our Privacy Policy.
+          </p>
+        </section>
+
+        <section>
+          <h2>7. Intellectual Property</h2>
+          <p>
+            The Email Sales Map application, including its design, code, and functionality, is owned by 
+            the developer. You are granted a limited, non-exclusive license to use the service.
+          </p>
+        </section>
+
+        <section>
+          <h2>8. Service Availability</h2>
+          <ul>
+            <li>We strive to maintain high availability but do not guarantee uninterrupted service</li>
+            <li>We may temporarily suspend the service for maintenance or updates</li>
+            <li>We reserve the right to modify or discontinue the service with reasonable notice</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>9. Limitation of Liability</h2>
+          <p>
+            Email Sales Map is provided "as is" without warranties of any kind. We are not liable for:
+          </p>
+          <ul>
+            <li>Any direct, indirect, incidental, or consequential damages</li>
+            <li>Loss of data or interruption of service</li>
+            <li>Any damages resulting from unauthorized access to your account</li>
+            <li>Inaccuracies in data visualization or country mapping</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>10. Google API Compliance</h2>
+          <p>
+            This service uses Google APIs and complies with Google's API Services User Data Policy. 
+            By using Email Sales Map, you acknowledge that your use is subject to Google's terms and policies.
+          </p>
+        </section>
+
+        <section>
+          <h2>11. Data Accuracy</h2>
+          <p>
+            While we strive for accuracy, we cannot guarantee that:
+          </p>
+          <ul>
+            <li>All sales emails will be correctly parsed</li>
+            <li>Country information extracted from emails is completely accurate</li>
+            <li>The world map visualization is error-free</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>12. Termination</h2>
+          <p>
+            Either party may terminate access to the service at any time. Upon termination:
+          </p>
+          <ul>
+            <li>Your access to the service will be immediately revoked</li>
+            <li>Any cached data will be automatically purged according to our retention policy</li>
+            <li>You may revoke Gmail access through your Google Account settings</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>13. Changes to Terms</h2>
+          <p>
+            We reserve the right to modify these terms at any time. Material changes will be 
+            communicated by updating the "Last updated" date. Continued use of the service 
+            constitutes acceptance of the modified terms.
+          </p>
+        </section>
+
+        <section>
+          <h2>14. Governing Law</h2>
+          <p>
+            These terms are governed by the laws of the United Kingdom. Any disputes will be 
+            resolved in the appropriate courts of the United Kingdom.
+          </p>
+        </section>
+
+        <section>
+          <h2>15. Contact Information</h2>
+          <p>
+            For questions about these Terms of Service, please contact:
+            <br />
+            Email: andrew.d.beveridge@gmail.com
+          </p>
+        </section>
+
+        <div class="legal-footer">
+          <a href="/">← Back to Email Sales Map</a>
+          <a href="/privacy">Privacy Policy</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Add static HTML versions for privacy and terms of service pages to ensure they are always accessible, even if the React app fails to initialize.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c04f2ef-18e7-4c70-a18c-d26f4ecb9c4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c04f2ef-18e7-4c70-a18c-d26f4ecb9c4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

